### PR TITLE
register `slt` as R instr

### DIFF
--- a/src/riscv_assembler/instr_arr.py
+++ b/src/riscv_assembler/instr_arr.py
@@ -357,7 +357,7 @@ reg_map, instr_map = register_map(), instruction_map()
 
 R_instr = [
 	"add","sub", "sll", 
-	"sltu", "xor", "srl", 
+	"slt", "sltu", "xor", "srl", 
 	"sra", "or", "and",
 	"addw", "subw", "sllw",
 	"slrw", "sraw", "mul",


### PR DESCRIPTION
1 slight change adding `slt` to the R-type instruction list; was previously erroring with `Exception: Bad Instruction Provided: slt!`

Anything else need to be added or fixed for this to be merged? Thanks!